### PR TITLE
Publish this repository as @automattic/yara npm package

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: npm install
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: npm install
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,22 @@
+# This workflow will publish this package to npm on each release created.
+# NPM_TOKEN secret needs to be created via https://www.npmjs.com/settings/a8c/tokens/ (choose automation token) and stored in this repository.
+
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,5 +1,7 @@
 # This workflow will publish this package to npm on each release created.
 # NPM_TOKEN secret needs to be created via https://www.npmjs.com/settings/a8c/tokens/ (choose automation token) and stored in this repository.
+#
+# See https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
 
 name: Publish to npm
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+        - '14.x'
+        - '16.x'
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libyara-dev
+        npm install
+
+#     - name: Run tests
+#       run: npm test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module is installed using [node package manager (npm)][npm]:
 	# during installation using node-gyp.  A suitable build chain
 	# must be configured before installation.
 
-	npm install yara
+	npm install @automattic/yara
 
 It is loaded using the `require()` function:
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yara",
+  "name": "@automattic/yara",
   "version": "2.2.0",
   "description": "YARA support for Node.js",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automattic/yara",
   "version": "2.2.0",
-  "description": "YARA support for Node.js",
+  "description": "Automattic's fork of YARA support for Node.js",
   "main": "index.js",
   "directories": {
     "example": "example"
@@ -22,7 +22,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/nospaceships/node-yara.git"
+    "url": "git://github.com/Automattic/node-yara.git"
   },
   "keywords": [
     "libyara",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/yara",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Automattic's fork of YARA support for Node.js",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This will allow us to publish this fork as a separate npm package.

I've followed [the instruction from `wp-calypso`](https://github.com/Automattic/wp-calypso/blob/trunk/docs/monorepo.md#getting-npm-permissions-to-publish-in-the-automattic-scope). Our fork of `yara-node` will be published to a8c namespace on npm.js.

* [x] created an automation token via https://www.npmjs.com/settings/a8c/tokens/
* [x] action secret `NPM)_TOKEN` added in https://github.com/Automattic/node-yara/settings/secrets/actions
* [x] [automate publishes to npm on each release](https://github.com/macbre/analyze-css/blob/devel/.github/workflows/npmpublish.yml)
* [x] run `npm install` as a CI step using both Node.js 14.x and 16.x 