### PR TITLE
Build binaries for both Linux and MacOS, add tests to the CI and do not rely on your system libyara version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,4 @@ jobs:
         path: ./build/Release/yara.node
 
     - name: Run tests
-      run: |
-        npm test || true
-
+      run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    # libyara 3.9 is supported
     - name: Install dependencies
       run: |
         sudo apt-get install libyara-dev
+        yara --version
 
     - name: Build binaries with node-pre-gyp
       run: |
+        set -x
         npm install --build-from-source
 
         npm install -g @mapbox/node-pre-gyp && node-pre-gyp unpublish package publish

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,5 +34,8 @@ jobs:
         set -x
         npm install --build-from-source
 
+        ls -lh ./build/Release
+        md5sum ./build/Release/yara.node
+
 #     - name: Run tests
 #       run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,18 +26,10 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # libyara 3.9 is supported
-    - name: Install dependencies
-      run: |
-        sudo apt-get install libyara-dev
-        yara --version
-
     - name: Build binaries with node-pre-gyp
       run: |
         set -x
         npm install --build-from-source
-
-        npm install -g @mapbox/node-pre-gyp && node-pre-gyp unpublish package publish
 
 #     - name: Run tests
 #       run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-        - '14.x'
-        - '16.x'
+        - '14'
+        - '16'
+        - '18'
         os:
         - 'ubuntu'
         - 'macos'
@@ -45,7 +46,7 @@ jobs:
     - name: Upload binaries as Action run artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: node${{ matrix.target-node }}-${{ matrix.os }}-yara
+        name: node${{ matrix.node-version }}-${{ matrix.os }}-yara
         path: ./build/Release/yara.node
 
 #     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,16 +17,16 @@ jobs:
         - '14.x'
         - '16.x'
         os:
-        - 'ubuntu-latest'
-        - 'macos-latest'
+        - 'ubuntu'
+        - 'macos'
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Setup MacOs
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos'
       run: brew install autoconf automake libmagic
 
     - name: Use Node.js ${{ matrix.node-version }}
@@ -41,6 +41,12 @@ jobs:
 
         ls -lh ./build/Release
         md5sum ./build/Release/yara.node || md5 ./build/Release/yara.node || true
+
+    - name: Upload binaries as Action run artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: node${{ matrix.target-node }}-${{ matrix.os }}-yara
+        path: ./build/Release/yara.node
 
 #     - name: Run tests
 #       run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@master
       with:
+        cache: npm
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
       run: |
         sudo apt-get install libyara-dev
-        npm install
+
+    - name: Build binaries with node-pre-gyp
+      run: |
+        npm install --build-from-source
+
+        npm install -g node-pre-gyp && node-pre-gyp unpublish package publish
 
 #     - name: Run tests
 #       run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,7 @@ jobs:
 
     - name: Setup MacOs
       if: matrix.os == 'macos-latest'
-      run: brew install \
-        autoconf \
-        automake \
-        libmagic
+      run: brew install autoconf automake libmagic
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Upload binaries as Action run artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: node${{ matrix.node-version }}-${{ matrix.os }}-yara
+        name: node${{ matrix.node-version }}-${{ matrix.os }}-yara.node
         path: ./build/Release/yara.node
 
 #     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@master
       with:
-        cache: npm
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,18 @@ jobs:
         - '14.x'
         - '16.x'
         os:
-        - ubuntu-latest
-        - macos-latest
+        - 'ubuntu-latest'
+        - 'macos-latest'
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup MacOs
+      if: matrix.os == 'macos-latest'
+      run: brew install autoconf automake
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@master
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         npm install --build-from-source
 
         ls -lh ./build/Release
-        md5sum ./build/Release/yara.node
+        md5sum ./build/Release/yara.node || md5 ./build/Release/yara.node || true
 
 #     - name: Run tests
 #       run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,10 @@ jobs:
 
     - name: Setup MacOs
       if: matrix.os == 'macos-latest'
-      run: brew install autoconf automake
+      run: brew install \
+        autoconf \
+        automake \
+        libmagic
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,5 +49,7 @@ jobs:
         name: node${{ matrix.node-version }}-${{ matrix.os }}-yara.node
         path: ./build/Release/yara.node
 
-#     - name: Run tests
-#       run: npm test
+    - name: Run tests
+      run: |
+        npm test || true
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
         node-version:
         - '14.x'
         - '16.x'
+        os:
+        - ubuntu-latest
+        - macos-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         npm install --build-from-source
 
-        npm install -g node-pre-gyp && node-pre-gyp unpublish package publish
+        npm install -g @mapbox/node-pre-gyp && node-pre-gyp unpublish package publish
 
 #     - name: Run tests
 #       run: npm test

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CFLAGS  += -I/usr/local/include
 LDFLAGS += -L/usr/local/lib
 endif
 
-YARA?=3.7.0
+YARA?=3.9.0
 
 libyara: yara
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+
+BASE=$(shell pwd)
+OSNAME=$(shell uname)
+
+CFGOPTS += --with-crypto
+CFGOPTS += --enable-magic
+
+ifeq ($(OSNAME),Darwin)
+CFLAGS  += -I/usr/local/include/node
+CFLAGS  += -I/usr/local/include
+LDFLAGS += -L/usr/local/lib
+endif
+
+YARA?=3.7.0
+
+libyara: yara
+
+yara:
+	-rm -rf $(BASE)/build/yara
+	-rm -rf $(BASE)/deps/yara-$(YARA)
+	test -f $(BASE)/deps/yara-$(YARA).tar.gz || curl -L -k https://github.com/VirusTotal/yara/archive/v$(YARA).tar.gz > $(BASE)/deps/yara-$(YARA).tar.gz
+	cd $(BASE)/deps && tar -xzvf yara-$(YARA).tar.gz
+	cd $(BASE)/deps/yara-$(YARA) && ./bootstrap.sh
+	cd $(BASE)/deps/yara-$(YARA) && \
+			CFLAGS="$(CFLAGS)" \
+			LDFLAGS="$(LDFLAGS)" \
+			./configure \
+					$(CFGOPTS) \
+					--enable-static \
+					--disable-shared \
+					--with-pic \
+					--prefix=$(BASE)/build/yara
+	cd $(BASE)/deps/yara-$(YARA) && make
+	cd $(BASE)/deps/yara-$(YARA) && make install

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,10 +10,12 @@
         "-fno-rtti"
       ],
       "include_dirs": [
-        "<!(node -e 'require(\"nan\")')"
+        "<!(node -e 'require(\"nan\")')",
+        "./build/yara/include"
       ],
       "libraries": [
-        "-lyara"
+        "-lmagic",
+        "../build/yara/lib/libyara.a"
       ],
       "conditions": [
         [
@@ -24,6 +26,21 @@
             }
           }
         ]
+      ],
+      "actions": [
+        {
+          "action_name": "build_libyara",
+          "inputs": [
+            "deps"
+          ],
+          "outputs": [
+            "build/yara"
+          ],
+          "action": [
+            "make",
+            "libyara"
+          ]
+        }
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -10,11 +10,6 @@
     "nan": "2.14.*",
     "typescript": "^3.8.3"
   },
-  "binary": {
-    "module_name": "yara",
-    "module_path": "./lib/binding/",
-    "host": "https://your_module.s3-us-west-1.amazonaws.com"
-  },
   "contributors": [
     {
       "name": "Stephen Vickers",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "nan": "2.14.*",
     "typescript": "^3.8.3"
   },
+  "binary": {
+    "module_name": "yara",
+    "module_path": "./lib/binding/",
+    "host": "https://your_module.s3-us-west-1.amazonaws.com"
+  },
   "contributors": [
     {
       "name": "Stephen Vickers",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "nan": "2.14.*",
     "typescript": "^3.8.3"
   },
+  "scripts": {
+    "test": "mocha test/*"
+  },
   "contributors": [
     {
       "name": "Stephen Vickers",
@@ -31,5 +34,8 @@
     "yara"
   ],
   "author": "NoSpaceships Ltd <hello@nospaceships.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "mocha": "^10.0.0"
+  }
 }

--- a/src/yara.cc
+++ b/src/yara.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <sstream>
 #include <mutex>
+#include <iostream>
 
 #include <errno.h>
 #include <stdio.h>
@@ -948,6 +949,8 @@ int scanCallback(int message, void* data, void* param) {
 NAN_METHOD(ScannerWrap::ReconfigureVariables) {
 	Nan::HandleScope scope;
 
+
+
 	ScannerWrap* scanner = ScannerWrap::Unwrap<ScannerWrap>(info.This());
 
 	std::lock_guard<std::mutex> lock(scanner->mutex);
@@ -1156,7 +1159,7 @@ NAN_METHOD(ScannerWrap::Scan) {
 
 	Local<Object> req = Nan::To<Object>(info[0]).ToLocalChecked();
 
-	char* filename = NULL;
+	std::string filename;
 	char *buffer = NULL;
 	int64_t offset = 0;
 	int64_t length = 0;
@@ -1164,8 +1167,10 @@ NAN_METHOD(ScannerWrap::Scan) {
 	int32_t timeout = 0;
 	int32_t matched_bytes = 0;
 
+
 	if (Nan::Get(req, Nan::New("filename").ToLocalChecked()).ToLocalChecked()->IsString()) {
 		Local<String> s = Nan::To<String>(Nan::Get(req, Nan::New("filename").ToLocalChecked()).ToLocalChecked()).ToLocalChecked();
+
 		filename = *Nan::Utf8String(s);
 	} else if (Nan::Get(req, Nan::New("buffer").ToLocalChecked()).ToLocalChecked()->IsObject()) {
 		Local<Object> o = Nan::To<Object>(Nan::Get(req, Nan::New("buffer").ToLocalChecked()).ToLocalChecked()).ToLocalChecked();
@@ -1230,7 +1235,7 @@ NAN_METHOD(ScannerWrap::Scan) {
 		}
 	}
 
-	if ((! filename) && (! buffer)) {
+	if ((filename.empty()) && (! buffer)) {
 		Nan::ThrowError("Either filename of buffer is required");
 		return;
 	}
@@ -1250,8 +1255,9 @@ NAN_METHOD(ScannerWrap::Scan) {
 
 	ScanReq* scan_req = new ScanReq();
 
-	if (filename)
-		scan_req->filename = filename;
+	if (!filename.empty()) {
+		scan_req->filename = filename.c_str();
+	}		
 
 	scan_req->buffer = buffer;
 	scan_req->offset = offset;
@@ -1272,6 +1278,7 @@ NAN_METHOD(ScannerWrap::Scan) {
 	Nan::AsyncQueueWorker(async_scan);
 
 	info.GetReturnValue().Set(info.This());
+
 }
 
 }; /* namespace yara */

--- a/src/yara.cc
+++ b/src/yara.cc
@@ -519,7 +519,11 @@ void compileCallback(int error_level, const char* file_name, int line_number,
 	CompileArgs* args = (CompileArgs*) user_data;
 
 	std::ostringstream oss;
-	oss << args->rule_config->index << ":" << line_number << ":" << message << ":" << file_name;
+	oss << args->rule_config->index << ":" << line_number << ":" << message << ":";
+
+	if (file_name != NULL) {
+		oss << file_name;
+	}
 
 	if (error_level == YARA_ERROR_LEVEL_WARNING)
 		args->configure->warnings.push_back(oss.str());


### PR DESCRIPTION
* https://github.com/springmeyer/node-addon-example
* https://github.com/mapbox/node-pre-gyp
* use [v3.9 of `libyara`](https://github.com/VirusTotal/yara/archive/refs/tags/v3.9.0.tar.gz) - revert 61782927f0f3c6f6d5ea9e2c7bf529fe95f538c5 so that we can always fetch the specific libyara version (for instance Mac's `brew` only has 3.10 which does not work with this package)
* have all pre-build binaries uploaded to the GH release ([an example](https://github.com/vercel/pkg-fetch/releases/tag/v3.4))

Have something similar to what `sqlite3` package does:

```
> sqlite3@5.0.2 install /home/runner/work/jetpack-backups/jetpack-backups/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build
node-pre-gyp WARN Using request for node-pre-gyp https download 
[sqlite3] Success: "/home/runner/work/jetpack-backups/jetpack-backups/node_modules/sqlite3/lib/binding/napi-v3-linux-x64/node_sqlite3.node" is installed via remote
```

Completed so far:

* [x] build binaries are upload as GH Action run artifacts
* [x] added Mocha - tests are now executed via `npm t` 

---

See my comment in https://github.com/Automattic/jetpack-backups/pull/1959#issuecomment-889137819