### PR TITLE
Add Yara 4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CFLAGS  += -I/usr/local/include
 LDFLAGS += -L/usr/local/lib
 endif
 
-YARA?=3.9.0
+YARA?=4.2.3
 
 libyara: yara
 

--- a/src/yara.cc
+++ b/src/yara.cc
@@ -41,10 +41,19 @@ enum VarType {
 
 #define ERROR_UNKNOWN_STRING "ERROR_UNKNOWN"
 
+#if YR_MAJOR_VERSION >= 4
+void compileCallback(int error_level, const char* file_name, int line_number,
+		const YR_RULE* rule, const char* message, void* user_data);
+#else
 void compileCallback(int error_level, const char* file_name, int line_number,
 		const char* message, void* user_data);
+#endif
 
+#if YR_MAJOR_VERSION >= 4
+int scanCallback(YR_SCAN_CONTEXT* scan_context, int message, void* data, void* param);
+#else
 int scanCallback(int message, void* data, void* param);
+#endif
 
 const char* getErrorString(int code) {
 	size_t count = error_codes.count(code);
@@ -513,9 +522,13 @@ private:
 	RuleConfigList* rule_configs_;
 	VarConfigList* var_configs_;
 };
-
+#if YR_MAJOR_VERSION >= 4
+void compileCallback(int error_level, const char* file_name, int line_number,
+		const YR_RULE* rule, const char* message, void* user_data) {
+#else
 void compileCallback(int error_level, const char* file_name, int line_number,
 		const char* message, void* user_data) {
+#endif
 	CompileArgs* args = (CompileArgs*) user_data;
 
 	std::ostringstream oss;
@@ -860,7 +873,11 @@ private:
 	ScanReq* scan_req_;
 };
 
+#if YR_MAJOR_VERSION >= 4
+int scanCallback(YR_SCAN_CONTEXT* scan_context, int message, void* data, void* param) {
+#else
 int scanCallback(int message, void* data, void* param) {
+#endif
 	AsyncScan* async_scan = (AsyncScan*) param;
 
 	YR_RULE* rule;
@@ -896,7 +913,11 @@ int scanCallback(int message, void* data, void* param) {
 			}
 
 			yr_rule_strings_foreach(rule, string) {
+				#if YR_MAJOR_VERSION >= 4
+				yr_string_matches_foreach(scan_context, string, match) {
+				#else
 				yr_string_matches_foreach(string, match) {
+				#endif
 					std::ostringstream oss;
 					oss << match->offset << ":" << match->match_length << ":" << string->identifier;
 

--- a/src/yara.cc
+++ b/src/yara.cc
@@ -42,19 +42,10 @@ enum VarType {
 
 #define ERROR_UNKNOWN_STRING "ERROR_UNKNOWN"
 
-#if YR_MAJOR_VERSION >= 4
 void compileCallback(int error_level, const char* file_name, int line_number,
 		const YR_RULE* rule, const char* message, void* user_data);
-#else
-void compileCallback(int error_level, const char* file_name, int line_number,
-		const char* message, void* user_data);
-#endif
 
-#if YR_MAJOR_VERSION >= 4
 int scanCallback(YR_SCAN_CONTEXT* scan_context, int message, void* data, void* param);
-#else
-int scanCallback(int message, void* data, void* param);
-#endif
 
 const char* getErrorString(int code) {
 	size_t count = error_codes.count(code);
@@ -523,13 +514,9 @@ private:
 	RuleConfigList* rule_configs_;
 	VarConfigList* var_configs_;
 };
-#if YR_MAJOR_VERSION >= 4
+
 void compileCallback(int error_level, const char* file_name, int line_number,
 		const YR_RULE* rule, const char* message, void* user_data) {
-#else
-void compileCallback(int error_level, const char* file_name, int line_number,
-		const char* message, void* user_data) {
-#endif
 	CompileArgs* args = (CompileArgs*) user_data;
 
 	std::ostringstream oss;
@@ -878,11 +865,7 @@ private:
 	ScanReq* scan_req_;
 };
 
-#if YR_MAJOR_VERSION >= 4
 int scanCallback(YR_SCAN_CONTEXT* scan_context, int message, void* data, void* param) {
-#else
-int scanCallback(int message, void* data, void* param) {
-#endif
 	AsyncScan* async_scan = (AsyncScan*) param;
 
 	YR_RULE* rule;
@@ -918,11 +901,7 @@ int scanCallback(int message, void* data, void* param) {
 			}
 
 			yr_rule_strings_foreach(rule, string) {
-				#if YR_MAJOR_VERSION >= 4
 				yr_string_matches_foreach(scan_context, string, match) {
-				#else
-				yr_string_matches_foreach(string, match) {
-				#endif
 					std::ostringstream oss;
 					oss << match->offset << ":" << match->match_length << ":" << string->identifier;
 

--- a/test/unit_index.js_scanner.configure.js
+++ b/test/unit_index.js_scanner.configure.js
@@ -54,7 +54,7 @@ describe("index.js", function() {
 					var expErrors = [{
 						index: 0,
 						line: 1,
-						message: "syntax error, unexpected '}', expecting <condition>"
+						message: "syntax error"
 					}]
 
 					assert.deepEqual(error.errors, expErrors)
@@ -78,7 +78,7 @@ describe("index.js", function() {
 					var expErrors = [{
 						index: 0,
 						line: 1,
-						message: "syntax error, unexpected '}', expecting <condition>"
+						message: "syntax error"
 					}]
 
 					assert.deepEqual(error.errors, expErrors)
@@ -114,7 +114,7 @@ describe("index.js", function() {
 						{
 							index: 0,
 							line: 4,
-							message: 'Using literal string "stephen" in a boolean operation.'
+							message: 'using literal string "stephen" in a boolean operation.'
 						}
 					]
 
@@ -160,7 +160,7 @@ describe("index.js", function() {
 					var expErrors = [{
 						index: 0,
 						line: 4,
-						message: "syntax error, unexpected hex string, expecting identifier"
+						message: "syntax error"
 					}]
 
 					assert.deepEqual(error.errors, expErrors)


### PR DESCRIPTION
Yara 4 has some slight breaking API changes. This makes the library compatible with 4. The version we're using is 4.2.3.

## Testing
- Verify that the tests passes.