### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,7 @@ This module implements [YARA][yara] bindings for [Node.js][nodejs].
 
 **This module is supported on Linux and MacOS (using homebrew) platforms only**
 
-This module uses the installed version of libyara 3.9. You should download,
-compile and install your preferred version, or use one of the following
-commands using your system package manager:
-
-	# CentOS/Red Hat
-	sudo yum install yara-devel
-	
-	# Debian/Ubuntu
-	sudo apt-get install libyara-dev
-	
-	# MacOS (using homebrew)
-	sudo brew install yara
+This module is built using libyara 4.0.
 
 This module is installed using [node package manager (npm)][npm]:
 


### PR DESCRIPTION
* we no longer depend on system-wide libyara
* since #6 we're using libyara 4.0