### PR TITLE
Don't hardcode architecture

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,10 +4,13 @@
       "target_name": "action_before_build",
       "type": "none",
       "copies": [],
+      "variables": {
+        'architecture': '<!(uname -m)'
+      },
       "conditions": [
         ['OS == "linux"', {
           "copies": [{
-            "files": [ "/usr/lib/x86_64-linux-gnu/libmagic.a" ],
+            "files": [ "/usr/lib/<(architecture)-linux-gnu/libmagic.a" ],
             "destination": "build/"
           }],
         }],


### PR DESCRIPTION
`libyara` might need to be built on ARM64 (`aarch64`) architecture too, e.g. I'm using a Mac with an M1 chip, and `node-yara` builds fail on my [dev-and-test environment](https://github.com/Automattic/jetpack-backups-dev-and-test-env-demo) as the containers run on ARM64 as well.

This sets the [GYP variable](https://gyp.gsrc.io/docs/InputFormatReference.md#command-expansions) to the output of `uname -m` command (which is typically either `x86_64` or `aarch64`), and later uses the variable to set the path to the static library.