### PR TITLE
Build binaries for different Node.js versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # https://github.com/actions/setup-node
     - name: Install Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@master
       with:
         node-version: ${{ matrix.node-version }}
-        cache: npm
 
     - name: Build binaries inside the container
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@master
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: npm
+
     - name: Build binaries inside the container
       run: |
         set -x
@@ -43,6 +49,8 @@ jobs:
 
         # what's the Node.js version?
         export ABI=$(node --eval 'console.log(process.versions.modules)')
+
+        echo "::notice::Building binary for node-yara package v${PACKAGE_VERSION} for Node.js v$(node -v) (ABI ${ABI}) ..."
 
         # build inside the container (pass the required Node.js version there) and copy the package to the host
         docker build --build-arg NODEJS=${{ matrix.node-version }} -t yara/debian .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-#        - '14'
         - '16'
-#        - '18'
+        - '18'
+        - '20'
 
     runs-on: ubuntu-22.04
 
@@ -68,9 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-#        - '14'
         - '16'
-#        - '18'
+        - '18'
+        - '20'
 
     runs-on: macos-12
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Build binaries inside the container
       run: |
         set -x
-        
+        node -v
+
         # what's the package version?
         # e.g.  Binary staged at "build/stage/Automattic/node-yara/raw/master/binaries/yara-v2.5.0-linux-x64.tar.gz"
         export PACKAGE_VERSION=$(jq -r .version package.json)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
         # what's the Node.js version?
         export ABI=$(node --eval 'console.log(process.versions.modules)')
 
-        # build inside the container and copy the package to the host
-        docker build -t yara/debian .
+        # build inside the container (pass the required Node.js version there) and copy the package to the host
+        docker build --build-arg NODEJS=${{ matrix.node-version }} -t yara/debian .
         docker images
 
         # e.g. yara-v2.5.0-linux-x64-node-v93.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,9 @@ jobs:
         # build inside the container and copy the package to the host
         docker build -t yara/debian .
         docker images
-        docker run --rm --volume /tmp:/tmp yara/debian cp ./binaries/yara-v${PACKAGE_VERSION}-linux-x64-node${ABI}.tar.gz /tmp
+
+        # e.g. yara-v2.5.0-linux-x64-node-v93.tar.gz
+        docker run --rm --volume /tmp:/tmp yara/debian cp ./binaries/yara-v${PACKAGE_VERSION}-linux-x64-node-v${ABI}.tar.gz /tmp
         ls -lh /tmp/yara-v${PACKAGE_VERSION}-*
 
         # copy it to the repository clone and see if there's a difference

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         # what's the Node.js version?
         export ABI=$(node --eval 'console.log(process.versions.modules)')
 
-        echo "::notice::Building binary for node-yara package v${PACKAGE_VERSION} for Node.js v$(node -v) (ABI ${ABI}) ..."
+        echo "::notice::Building binary for node-yara package v${PACKAGE_VERSION} for Node.js $(node -v) (ABI ${ABI}) ..."
 
         # build inside the container (pass the required Node.js version there) and copy the package to the host
         docker build --build-arg NODEJS=${{ matrix.node-version }} -t yara/debian .
@@ -109,7 +109,7 @@ jobs:
 
         # what's the Node.js version?
         export ABI=$(node --eval 'console.log(process.versions.modules)')
-        echo "::notice::Building binary for node-yara package v${PACKAGE_VERSION} for Node.js v$(node -v) (ABI ${ABI}) ..."
+        echo "::notice::Building binary for node-yara package v${PACKAGE_VERSION} for Node.js $(node -v) (ABI ${ABI}) ..."
 
         npm install --ignore-scripts
         time -p npx node-pre-gyp configure rebuild
@@ -124,6 +124,8 @@ jobs:
     - name: Run tests
       run: npm test
 
+    # TODO: publish as the release artifacts
+    #
     # By default, the commit is made in the name of "GitHub Actions"
     # and co-authored by the user that made the last commit.
     # https://github.com/marketplace/actions/git-auto-commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,15 @@ jobs:
     - name: Build binaries with node-pre-gyp
       run: |
         set -x
+
+        # what's the package version?
+        # e.g.  Binary staged at "build/stage/Automattic/node-yara/raw/master/binaries/yara-v2.5.0-linux-x64.tar.gz"
+        export PACKAGE_VERSION=$(jq -r .version package.json)
+
+        # what's the Node.js version?
+        export ABI=$(node --eval 'console.log(process.versions.modules)')
+        echo "::notice::Building binary for node-yara package v${PACKAGE_VERSION} for Node.js v$(node -v) (ABI ${ABI}) ..."
+
         npm install --ignore-scripts
         time -p npx node-pre-gyp configure rebuild
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,13 @@ jobs:
         # e.g.  Binary staged at "build/stage/Automattic/node-yara/raw/master/binaries/yara-v2.5.0-linux-x64.tar.gz"
         export PACKAGE_VERSION=$(jq -r .version package.json)
 
+        # what's the Node.js version?
+        export ABI=$(node --eval 'console.log(process.versions.modules)')
+
         # build inside the container and copy the package to the host
         docker build -t yara/debian .
         docker images
-        docker run --rm --volume /tmp:/tmp yara/debian cp ./binaries/yara-v${PACKAGE_VERSION}-linux-x64.tar.gz /tmp
+        docker run --rm --volume /tmp:/tmp yara/debian cp ./binaries/yara-v${PACKAGE_VERSION}-linux-x64-node${ABI}.tar.gz /tmp
         ls -lh /tmp/yara-v${PACKAGE_VERSION}-*
 
         # copy it to the repository clone and see if there's a difference

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # this container is used to build binaries for Debian 10 (aka oldstable)
-FROM node:16.16-buster-slim
+ARG NODEJS=16.16
+FROM node:$NODEJS-buster-slim
 
 RUN apt-get update -y && \
 	apt-get install -y \

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "module_path": "./build/Release",
     "host": "https://github.com/",
     "remote_path": "/Automattic/node-yara/raw/master/binaries/",
-    "package_name": "{module_name}-v{version}-{platform}-{arch}-node{node_abi}.tar.gz"
+    "package_name": "{module_name}-v{version}-{platform}-{arch}-{node_abi}.tar.gz"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "module_path": "./build/Release",
     "host": "https://github.com/",
     "remote_path": "/Automattic/node-yara/raw/master/binaries/",
-    "package_name": "{module_name}-v{version}-{platform}-{arch}.tar.gz"
+    "package_name": "{module_name}-v{version}-{platform}-{arch}-node{node_abi}.tar.gz"
   },
   "contributors": [
     {


### PR DESCRIPTION
We should be able to serve pre-built binaries for different Node.js versions: 16.x, 18.x and 20.x.

Instead of:

* yara-v2.5.0-darwin-x64.tar.gz
* yara-v2.5.0-linux-x64.tar.gz

commit the following files to the `binaries/` directory with [the `node_abi` parameter](https://www.npmjs.com/package/node-pre-gyp#versioning):

* yara-v2.5.0-linux-x64-node-v93.tar.gz (Node 16.x)
* yara-v2.5.0-linux-x64-node-v108.tar.gz (Node 18.x)
* yara-v2.5.0-darwin-x64-node-v115.tar.gz (Node 20.x)
* ...

<img width="638" alt="Screenshot 2023-08-30 at 17 17 33" src="https://github.com/Automattic/node-yara/assets/1929317/bed4e7f7-363b-4e11-88d4-e5556d1bcb76">

For instance:

```
$ node -v
v18.17.1
$ node --eval 'console.log(process.versions.modules)' 
108

$ node -v
v16.16.0
$ node --eval 'console.log(process.versions.modules)'
93
```

The install tests are failing as there are still no new binaries committed to the repo.

## TODO

* [x] linux build pipeline works
* [x] darwin build pipeline works