### PR TITLE
node-yara: tag v2.6.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automattic/yara",
-  "version": "2.5.0",
-  "description": "Automattic's fork of YARA support for Node.js",
+  "version": "2.6.0-beta.1",
+  "description": "Automattic's fork of YARA support for Node.js with pre-built binaries",
   "main": "index.js",
   "directories": {
     "example": "example"


### PR DESCRIPTION
Let's try to build and publish a new version with multiple Node.js versions support.

This is a follow-up of #28.