### PR TITLE
Ignore more directories when preparing the package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,8 @@ jobs:
         # copy it to the repository clone
         cp /tmp/yara-v${PACKAGE_VERSION}-* ./binaries
 
+        npm publish --dry-run
+
     - name: git status
       run: |
         # see if there's a difference

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,7 @@
-build
-deps/yara-3.6.0
+.github/
+build/
+binaries/
+deps/yara-*
 node_modules
+test/
 TODO.md


### PR DESCRIPTION
Resolves #53

```
npm notice package size:  18.1 kB
npm notice unpacked size: 69.5 kB
```

vs

https://www.npmjs.com/package/@automattic/yara/v/2.6.0-beta.2 -> Unpacked Size / 8.93 MB